### PR TITLE
게임이 끝나지 않는 버그 수정

### DIFF
--- a/Galaga/Form1.cs
+++ b/Galaga/Form1.cs
@@ -49,7 +49,7 @@ namespace Galaga {
                 
                 MessageBox.Show("게임 오버!", "게임 오버");
                 Close();
-            } else if (_manager.State is CompleteState) {
+            } else if (_manager.State is CompleteState || _manager.State is CompleteAllState) {
                 _timer.Enabled = false;
 
                 MessageBox.Show("게임 클리어", "게임 클리어");

--- a/Galaga/Game/GameManager.cs
+++ b/Galaga/Game/GameManager.cs
@@ -150,39 +150,18 @@ namespace Galaga.Game {
 
 
 			if (game.IsCleared()) {
-				if (!HasGameCleared()) return;
-
 				if (_manager.Stage >= _manager.GetMaxStage()) {
 					// 모든 스테이지를 클리어
 					_manager.State = new CompleteAllState(_manager);
 					return;
 				}
 
-				var nextState = new CompleteState(_manager);
-
-				var timer = new Timer {
-					Interval = 5000, // 5초 후에 스테이지 준비 상태로 변경
-					Enabled = true
-				};
-				timer.Elapsed += (sender, args) => {
-					if (_manager.State == nextState) {
-						_manager.State = new IntermediateState(_manager);
-					}
-				};
-
-				_manager.State = nextState;
+				_manager.State = new CompleteState(_manager);
 
 				_manager.SetStage(_manager.Stage + 1);
 			} else if (game.IsOver()) {
 				_manager.State = new GameOverState(_manager);
 			}
-		}
-
-		private bool HasGameCleared() {
-			// TODO 게임 클리어 조건 정의
-
-			//return new Random().NextDouble() < 0.01;
-			return false;
 		}
 	}
 


### PR DESCRIPTION
게임의 종료 조건이 완전히 정의되지 않았을 때 작업된 코드가 이상한 곳에 남아있어서 보스가 죽어도 게임이 끝나지 않는 버그를 수정했습니다. 보스가 죽은 후에 플레이어가 죽어도 게임 오버되지 않는 버그도 함께 수정되었습니다.